### PR TITLE
add epel repo to common role

### DIFF
--- a/roles/common/tasks/install_epel_repo.yml
+++ b/roles/common/tasks/install_epel_repo.yml
@@ -1,0 +1,5 @@
+- name: Add EPEL repository
+  yumrepo:
+    name: epel
+    description: EPEL YUM repo
+    baseurl: http://download.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{{ ansible_base_architecture }}

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -2,6 +2,9 @@
 - include: install_yum_pkgs.yml
   when: ansible_pkg_mgr == 'yum'
 
+- include: install_epel_repo.yml
+  when: ansible_pkg_mgr == 'yum'
+
 - include: install_apt_pkgs.yml
   when: ansible_pkg_mgr == 'apt'
 


### PR DESCRIPTION
adds EPEL repository to all boxes with yum package manager. Accounts for major release version, and architecture
